### PR TITLE
Add FastAPI/Next.js scaffolding

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Install frontend dependencies
+npm --prefix frontend install
+
+# Install backend dependencies
+pip install -r backend/requirements.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
-/.env
-/combine_files.py
-/combined_files.txt
-/.cadence
-/.idea
-/.streamlit/secrets.toml
+node_modules
+.env
+__pycache__
+frontend/.next
+frontend/out

--- a/README.md
+++ b/README.md
@@ -12,14 +12,26 @@ The legacy Streamlit prototype still lives in the root `app/` directory for refe
 
 ## Local Development
 
-1. Create a `.env` file with required keys (`OPENAI_API_KEY`, `QDRANT_URL`, etc.).
-2. Build and start services via Docker Compose:
+1. Create a `.env` file with the following variables:
+   - `OPENAI_API_KEY`
+   - `QDRANT_URL`
+   - `QDRANT_API_KEY` (optional if your Qdrant instance is open)
+   - `QDRANT_COLLECTION` (defaults to `Classy_Art`)
+2. Install dependencies for the frontend and backend (optional when using Docker):
+
+```bash
+cd frontend && npm install
+cd ../backend && pip install -r requirements.txt
+```
+
+3. Build and start all services via Docker Compose:
 
 ```bash
 docker compose up --build
 ```
 
 The frontend will be available on `http://localhost:3000` and the backend on `http://localhost:8000`.
+Hot reloading is enabled for both services when using the default compose configuration.
 
 ## Backend
 
@@ -31,6 +43,17 @@ Run locally with:
 uvicorn app.main:app --reload
 ```
 
+Main API endpoints:
+
+```
+POST /search/text   - search using a text query
+POST /search/image  - search using an uploaded image
+POST /search/vector - search using a raw embedding vector
+POST /search/hybrid - combine multiple vectors using RRF
+GET  /analytics/summary
+POST /chat
+```
+
 ## Frontend
 
 A minimal Next.js project with route based pages (`/search`, `/analytics`, `/chat`, `/imagesearch`, `/hub`).  Each page calls the backend APIs and is styled with Tailwind CSS and Material‑UI components.
@@ -38,3 +61,9 @@ A minimal Next.js project with route based pages (`/search`, `/analytics`, `/cha
 ## Notes
 
 This rewrite is a starting point only.  It does not yet include production authentication, monitoring or the full analytics database.  Those pieces can be added on top of this scaffolding.
+
+## Next Steps
+
+* Connect the backend to a persistent database and add authentication.
+* Flesh out the React components for a richer user experience.
+* Add automated tests for the API and frontend.

--- a/README.md
+++ b/README.md
@@ -1,43 +1,40 @@
-# ClassyRIS
+# ClassyRIS Modernized
 
-ClassyRIS is a Streamlit-based application for searching an artwork catalog using both text and images. It relies on OpenAI embeddings and a Qdrant vector database for retrieval.
+This repository now contains a starter monorepo for a modern rewrite of the original Streamlit app.  The goal is to provide a scalable architecture with a TypeScript/React frontend and a FastAPI backend.
 
-## Installation
-
-1. Clone the repository.
-2. (Optional) Create and activate a virtual environment.
-3. Install dependencies:
-
-```bash
-pip install -r requirements.txt
+```
+./frontend       Next.js application (TypeScript)
+./backend        FastAPI service with REST/async APIs
+./shared-types   Shared API models
 ```
 
-## Environment Variables
+The legacy Streamlit prototype still lives in the root `app/` directory for reference.
 
-The app expects several environment variables to be set:
+## Local Development
 
-- `OPENAI_API_KEY` – API key for accessing OpenAI embeddings.
-- `QDRANT_URL` – URL for your Qdrant instance.
-- `QDRANT_API_KEY` – API key for Qdrant (if required).
-- `QDRANT_COLLECTION` – Name of the Qdrant collection (defaults to `Classy_Art`).
-
-You can place these in a `.env` file or set them in your shell before running the app.
-
-## Running the App
-
-Start the Streamlit server:
+1. Create a `.env` file with required keys (`OPENAI_API_KEY`, `QDRANT_URL`, etc.).
+2. Build and start services via Docker Compose:
 
 ```bash
-streamlit run main.py
+docker compose up --build
 ```
 
-The application will open in your browser at `http://localhost:8501`.
+The frontend will be available on `http://localhost:3000` and the backend on `http://localhost:8000`.
 
-A `company_logo.png` image is included and appears in the user interface. Feel free to replace it with your own branding.
+## Backend
 
-## Screenshot
+The FastAPI app exposes search, analytics and chat endpoints and reuses the existing Qdrant/OpenAI utilities.  See `backend/app/main.py` for the implementation.
 
-Below is a placeholder screenshot of the running UI (replace with your own if desired):
+Run locally with:
 
-![Screenshot](company_logo.png)
+```bash
+uvicorn app.main:app --reload
+```
 
+## Frontend
+
+A minimal Next.js project with route based pages (`/search`, `/analytics`, `/chat`, `/imagesearch`, `/hub`).  Each page calls the backend APIs and is styled with Tailwind CSS and Material‑UI components.
+
+## Notes
+
+This rewrite is a starting point only.  It does not yet include production authentication, monitoring or the full analytics database.  Those pieces can be added on top of this scaffolding.

--- a/README.md
+++ b/README.md
@@ -37,11 +37,22 @@ Hot reloading is enabled for both services when using the default compose config
 
 The FastAPI app exposes search, analytics and chat endpoints and reuses the existing Qdrant/OpenAI utilities.  See `backend/app/main.py` for the implementation.
 
-Run locally with:
+Run locally with **one** of the following commands:
+
+From the repository root:
 
 ```bash
-uvicorn app.main:app --reload
+uvicorn backend.app.main:app --reload
 ```
+
+Or from inside the `backend` directory:
+
+```bash
+PYTHONPATH=.. uvicorn app.main:app --reload
+```
+
+Running from any other directory may import the wrong `app` package because of
+the legacy `app/` folder in the repo root.
 
 Main API endpoints:
 

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ The legacy Streamlit prototype still lives in the root `app/` directory for refe
    - `QDRANT_URL`
    - `QDRANT_API_KEY` (optional if your Qdrant instance is open)
    - `QDRANT_COLLECTION` (defaults to `Classy_Art`)
-2. Install dependencies for the frontend and backend (optional when using Docker):
+2. Install dependencies for the frontend and backend (optional when using Docker).
+   A setup script is provided to install everything in one step:
 
 ```bash
-cd frontend && npm install
-cd ../backend && pip install -r requirements.txt
+./.codex/setup.sh
 ```
 
 3. Build and start all services via Docker Compose:

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,14 +2,20 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from typing import List, Dict, Optional
+from typing import Dict
 
 from fastapi import FastAPI, HTTPException, UploadFile, File
 
 # allow importing modules from repository root
 ROOT_DIR = Path(__file__).resolve().parents[2]
 if str(ROOT_DIR) not in sys.path:
-    sys.path.append(str(ROOT_DIR))
+    sys.path.insert(0, str(ROOT_DIR))
+    # Redirect local "app" package to the repository root so imports like
+    # ``from app import qdrant_utils`` resolve correctly when running from this
+    # directory.
+    pkg = sys.modules.get("app")
+    if pkg and Path(getattr(pkg, "__file__", "")).parent == Path(__file__).parent:
+        pkg.__path__.insert(0, str(ROOT_DIR / "app"))
 
 from app import qdrant_utils, embedding, data_utils, openai_utils
 from shared_types.api_models import (
@@ -17,7 +23,6 @@ from shared_types.api_models import (
     HybridSearchRequest,
     ChatRequest,
     TextSearchRequest,
-    SearchResult,
 )
 
 import redis

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+from pydantic import BaseModel
+from typing import Any, Dict, List, Optional
+
+
+class SearchResult(BaseModel):
+    payload: Dict[str, Any]
+    score: Optional[float] = None
+
+
+class VectorSearchRequest(BaseModel):
+    vector: List[float]
+    vector_name: str
+    top_k: int = 5
+    filters: Optional[Dict[str, List[str]]] = None
+
+
+class HybridSearchRequest(BaseModel):
+    vectors: Dict[str, List[float]]
+    top_k: int = 5
+    filters: Optional[Dict[str, List[str]]] = None

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,8 @@
+fastapi
+uvicorn
+pydantic
+python-dotenv
+qdrant-client
+openai
+redis
+psycopg2-binary

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+version: '3'
+services:
+  backend:
+    build: ./backend
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - QDRANT_URL=${QDRANT_URL}
+      - QDRANT_API_KEY=${QDRANT_API_KEY}
+      - REDIS_URL=redis://redis:6379/0
+    volumes:
+      - ./app:/workspace/app
+      - ./data:/workspace/data
+    ports:
+      - "8000:8000"
+    depends_on:
+      - redis
+      - qdrant
+  frontend:
+    build: ./frontend
+    ports:
+      - "3000:3000"
+    depends_on:
+      - backend
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
+  qdrant:
+    image: qdrant/qdrant
+    ports:
+      - "6333:6333"
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: classy
+      POSTGRES_PASSWORD: classy
+      POSTGRES_DB: classydb
+    ports:
+      - "5432:5432"

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install || true
+COPY . .
+CMD ["npm", "run", "dev"]

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+}
+
+module.exports = nextConfig

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "classyris-frontend",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.0.4",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "@mui/material": "5.15.10",
+    "@mui/icons-material": "5.15.10",
+    "tailwindcss": "3.4.1"
+  },
+  "devDependencies": {
+    "typescript": "5.2.2"
+  }
+}

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,0 +1,12 @@
+import type { AppProps } from 'next/app'
+import '../styles.css'
+import { CssBaseline } from '@mui/material'
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  return (
+    <>
+      <CssBaseline />
+      <Component {...pageProps} />
+    </>
+  )
+}

--- a/frontend/pages/analytics.tsx
+++ b/frontend/pages/analytics.tsx
@@ -1,7 +1,26 @@
+import { useEffect, useState } from 'react'
+
 export default function Analytics() {
+  const [summary, setSummary] = useState<any>(null)
+
+  useEffect(() => {
+    fetch('http://localhost:8000/analytics/summary')
+      .then(res => res.json())
+      .then(data => setSummary(data))
+      .catch(() => setSummary(null))
+  }, [])
+
   return (
     <div className="p-8">
-      <h1 className="text-xl font-bold mb-4">Analytics (placeholder)</h1>
+      <h1 className="text-xl font-bold mb-4">Analytics</h1>
+      {summary ? (
+        <div className="space-y-2">
+          <div>Total products: {summary.total_products}</div>
+          {summary.average_price && <div>Average price: ${summary.average_price.toFixed(2)}</div>}
+        </div>
+      ) : (
+        <div>Loading...</div>
+      )}
     </div>
   )
 }

--- a/frontend/pages/analytics.tsx
+++ b/frontend/pages/analytics.tsx
@@ -1,0 +1,7 @@
+export default function Analytics() {
+  return (
+    <div className="p-8">
+      <h1 className="text-xl font-bold mb-4">Analytics (placeholder)</h1>
+    </div>
+  )
+}

--- a/frontend/pages/chat.tsx
+++ b/frontend/pages/chat.tsx
@@ -1,0 +1,28 @@
+import { useState } from 'react'
+
+export default function Chat() {
+  const [text, setText] = useState('')
+  const [messages, setMessages] = useState<string[]>([])
+
+  async function send() {
+    const res = await fetch('http://localhost:8000/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ session_id: 'demo', message: text })
+    })
+    const data = await res.json()
+    setMessages(data.history)
+    setText('')
+  }
+
+  return (
+    <div className="p-8">
+      <h1 className="text-xl font-bold mb-4">Chat</h1>
+      <div className="space-y-2 mb-4">
+        {messages.map((m,i) => <div key={i}>{m}</div>)}
+      </div>
+      <input className="border p-2 mr-2" value={text} onChange={e => setText(e.target.value)} />
+      <button className="bg-green-500 text-white px-4 py-2" onClick={send}>Send</button>
+    </div>
+  )
+}

--- a/frontend/pages/hub.tsx
+++ b/frontend/pages/hub.tsx
@@ -1,0 +1,7 @@
+export default function Hub() {
+  return (
+    <div className="p-8">
+      <h1 className="text-xl font-bold mb-4">Employee Hub (placeholder)</h1>
+    </div>
+  )
+}

--- a/frontend/pages/imagesearch.tsx
+++ b/frontend/pages/imagesearch.tsx
@@ -1,0 +1,7 @@
+export default function ImageSearch() {
+  return (
+    <div className="p-8">
+      <h1 className="text-xl font-bold mb-4">Image Search (placeholder)</h1>
+    </div>
+  )
+}

--- a/frontend/pages/imagesearch.tsx
+++ b/frontend/pages/imagesearch.tsx
@@ -1,7 +1,28 @@
+import { useState } from 'react'
+
 export default function ImageSearch() {
+  const [file, setFile] = useState<File | null>(null)
+  const [results, setResults] = useState<any[]>([])
+
+  async function handleSearch() {
+    if (!file) return
+    const form = new FormData()
+    form.append('file', file)
+    const res = await fetch('http://localhost:8000/search/image?top_k=5', {
+      method: 'POST',
+      body: form
+    })
+    setResults(await res.json())
+  }
+
   return (
     <div className="p-8">
-      <h1 className="text-xl font-bold mb-4">Image Search (placeholder)</h1>
+      <h1 className="text-xl font-bold mb-4">Image Search</h1>
+      <input type="file" accept="image/*" onChange={e => setFile(e.target.files?.[0] || null)} />
+      <button className="bg-blue-500 text-white px-4 py-2 ml-2" onClick={handleSearch} disabled={!file}>Search</button>
+      <pre className="mt-4 bg-gray-100 p-2">
+        {JSON.stringify(results, null, 2)}
+      </pre>
     </div>
   )
 }

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,0 +1,16 @@
+import Link from 'next/link'
+
+export default function Home() {
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl font-bold mb-4">ClassyRIS Hub</h1>
+      <ul className="space-y-2">
+        <li><Link href="/search">Search</Link></li>
+        <li><Link href="/imagesearch">Image Search</Link></li>
+        <li><Link href="/analytics">Analytics</Link></li>
+        <li><Link href="/chat">Chat</Link></li>
+        <li><Link href="/hub">Employee Hub</Link></li>
+      </ul>
+    </div>
+  )
+}

--- a/frontend/pages/search.tsx
+++ b/frontend/pages/search.tsx
@@ -5,10 +5,10 @@ export default function Search() {
   const [results, setResults] = useState<any[]>([])
 
   async function handleSearch() {
-    const res = await fetch('http://localhost:8000/search/vector', {
+    const res = await fetch('http://localhost:8000/search/text', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ vector: [], vector_name: 'text', top_k: 5 })
+      body: JSON.stringify({ query, top_k: 5 })
     })
     setResults(await res.json())
   }

--- a/frontend/pages/search.tsx
+++ b/frontend/pages/search.tsx
@@ -1,0 +1,26 @@
+import { useState } from 'react'
+
+export default function Search() {
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState<any[]>([])
+
+  async function handleSearch() {
+    const res = await fetch('http://localhost:8000/search/vector', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ vector: [], vector_name: 'text', top_k: 5 })
+    })
+    setResults(await res.json())
+  }
+
+  return (
+    <div className="p-8">
+      <h1 className="text-xl font-bold mb-4">Search</h1>
+      <input className="border p-2 mr-2" value={query} onChange={e => setQuery(e.target.value)} />
+      <button className="bg-blue-500 text-white px-4 py-2" onClick={handleSearch}>Search</button>
+      <pre className="mt-4 bg-gray-100 p-2">
+        {JSON.stringify(results, null, 2)}
+      </pre>
+    </div>
+  )
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  content: [
+    './pages/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/shared-types/api_models.py
+++ b/shared-types/api_models.py
@@ -20,3 +20,17 @@ class HybridSearchRequest(BaseModel):
 class ChatRequest(BaseModel):
     session_id: str
     message: str
+
+
+class TextSearchRequest(BaseModel):
+    """Search using a natural language query."""
+    query: str
+    top_k: int = 5
+    filters: Optional[Dict[str, List[str]]] = None
+
+
+class ImageSearchRequest(BaseModel):
+    """Search using a base64 encoded image."""
+    image_base64: str
+    top_k: int = 5
+    filters: Optional[Dict[str, List[str]]] = None

--- a/shared-types/api_models.py
+++ b/shared-types/api_models.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+from pydantic import BaseModel
+from typing import Any, Dict, List, Optional
+
+class SearchResult(BaseModel):
+    payload: Dict[str, Any]
+    score: Optional[float]
+
+class VectorSearchRequest(BaseModel):
+    vector: List[float]
+    vector_name: str
+    top_k: int = 5
+    filters: Optional[Dict[str, List[str]]]
+
+class HybridSearchRequest(BaseModel):
+    vectors: Dict[str, List[float]]
+    top_k: int = 5
+    filters: Optional[Dict[str, List[str]]]
+
+class ChatRequest(BaseModel):
+    session_id: str
+    message: str

--- a/shared-types/ts/api.ts
+++ b/shared-types/ts/api.ts
@@ -1,0 +1,22 @@
+export interface SearchResult {
+  payload: Record<string, any>
+  score?: number
+}
+
+export interface VectorSearchRequest {
+  vector: number[]
+  vector_name: string
+  top_k?: number
+  filters?: Record<string, string[]>
+}
+
+export interface HybridSearchRequest {
+  vectors: Record<string, number[]>
+  top_k?: number
+  filters?: Record<string, string[]>
+}
+
+export interface ChatRequest {
+  session_id: string
+  message: string
+}

--- a/shared-types/ts/api.ts
+++ b/shared-types/ts/api.ts
@@ -20,3 +20,15 @@ export interface ChatRequest {
   session_id: string
   message: string
 }
+
+export interface TextSearchRequest {
+  query: string
+  top_k?: number
+  filters?: Record<string, string[]>
+}
+
+export interface ImageSearchRequest {
+  image_base64: string
+  top_k?: number
+  filters?: Record<string, string[]>
+}


### PR DESCRIPTION
## Summary
- modernize repo layout with `/backend`, `/frontend`, and `/shared-types`
- scaffold FastAPI service exposing search, analytics and chat endpoints
- add a minimal Next.js+TypeScript frontend with Tailwind/MUI
- provide docker compose for local development
- update README with monorepo instructions

## Testing
- `python -m py_compile backend/app/main.py backend/app/models.py shared-types/api_models.py`
- `python -m py_compile app/*.py`