### PR TITLE
Add search endpoints and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,26 @@ The legacy Streamlit prototype still lives in the root `app/` directory for refe
 
 ## Local Development
 
-1. Create a `.env` file with required keys (`OPENAI_API_KEY`, `QDRANT_URL`, etc.).
-2. Build and start services via Docker Compose:
+1. Create a `.env` file with the following variables:
+   - `OPENAI_API_KEY`
+   - `QDRANT_URL`
+   - `QDRANT_API_KEY` (optional if your Qdrant instance is open)
+   - `QDRANT_COLLECTION` (defaults to `Classy_Art`)
+2. Install dependencies for the frontend and backend (optional when using Docker):
+
+```bash
+cd frontend && npm install
+cd ../backend && pip install -r requirements.txt
+```
+
+3. Build and start all services via Docker Compose:
 
 ```bash
 docker compose up --build
 ```
 
 The frontend will be available on `http://localhost:3000` and the backend on `http://localhost:8000`.
+Hot reloading is enabled for both services when using the default compose configuration.
 
 ## Backend
 
@@ -31,6 +43,17 @@ Run locally with:
 uvicorn app.main:app --reload
 ```
 
+Main API endpoints:
+
+```
+POST /search/text   - search using a text query
+POST /search/image  - search using an uploaded image
+POST /search/vector - search using a raw embedding vector
+POST /search/hybrid - combine multiple vectors using RRF
+GET  /analytics/summary
+POST /chat
+```
+
 ## Frontend
 
 A minimal Next.js project with route based pages (`/search`, `/analytics`, `/chat`, `/imagesearch`, `/hub`).  Each page calls the backend APIs and is styled with Tailwind CSS and Material‑UI components.
@@ -38,3 +61,9 @@ A minimal Next.js project with route based pages (`/search`, `/analytics`, `/cha
 ## Notes
 
 This rewrite is a starting point only.  It does not yet include production authentication, monitoring or the full analytics database.  Those pieces can be added on top of this scaffolding.
+
+## Next Steps
+
+* Connect the backend to a persistent database and add authentication.
+* Flesh out the React components for a richer user experience.
+* Add automated tests for the API and frontend.

--- a/frontend/pages/analytics.tsx
+++ b/frontend/pages/analytics.tsx
@@ -1,7 +1,26 @@
+import { useEffect, useState } from 'react'
+
 export default function Analytics() {
+  const [summary, setSummary] = useState<any>(null)
+
+  useEffect(() => {
+    fetch('http://localhost:8000/analytics/summary')
+      .then(res => res.json())
+      .then(data => setSummary(data))
+      .catch(() => setSummary(null))
+  }, [])
+
   return (
     <div className="p-8">
-      <h1 className="text-xl font-bold mb-4">Analytics (placeholder)</h1>
+      <h1 className="text-xl font-bold mb-4">Analytics</h1>
+      {summary ? (
+        <div className="space-y-2">
+          <div>Total products: {summary.total_products}</div>
+          {summary.average_price && <div>Average price: ${summary.average_price.toFixed(2)}</div>}
+        </div>
+      ) : (
+        <div>Loading...</div>
+      )}
     </div>
   )
 }

--- a/frontend/pages/imagesearch.tsx
+++ b/frontend/pages/imagesearch.tsx
@@ -1,7 +1,28 @@
+import { useState } from 'react'
+
 export default function ImageSearch() {
+  const [file, setFile] = useState<File | null>(null)
+  const [results, setResults] = useState<any[]>([])
+
+  async function handleSearch() {
+    if (!file) return
+    const form = new FormData()
+    form.append('file', file)
+    const res = await fetch('http://localhost:8000/search/image?top_k=5', {
+      method: 'POST',
+      body: form
+    })
+    setResults(await res.json())
+  }
+
   return (
     <div className="p-8">
-      <h1 className="text-xl font-bold mb-4">Image Search (placeholder)</h1>
+      <h1 className="text-xl font-bold mb-4">Image Search</h1>
+      <input type="file" accept="image/*" onChange={e => setFile(e.target.files?.[0] || null)} />
+      <button className="bg-blue-500 text-white px-4 py-2 ml-2" onClick={handleSearch} disabled={!file}>Search</button>
+      <pre className="mt-4 bg-gray-100 p-2">
+        {JSON.stringify(results, null, 2)}
+      </pre>
     </div>
   )
 }

--- a/frontend/pages/search.tsx
+++ b/frontend/pages/search.tsx
@@ -5,10 +5,10 @@ export default function Search() {
   const [results, setResults] = useState<any[]>([])
 
   async function handleSearch() {
-    const res = await fetch('http://localhost:8000/search/vector', {
+    const res = await fetch('http://localhost:8000/search/text', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ vector: [], vector_name: 'text', top_k: 5 })
+      body: JSON.stringify({ query, top_k: 5 })
     })
     setResults(await res.json())
   }

--- a/shared-types/api_models.py
+++ b/shared-types/api_models.py
@@ -20,3 +20,17 @@ class HybridSearchRequest(BaseModel):
 class ChatRequest(BaseModel):
     session_id: str
     message: str
+
+
+class TextSearchRequest(BaseModel):
+    """Search using a natural language query."""
+    query: str
+    top_k: int = 5
+    filters: Optional[Dict[str, List[str]]] = None
+
+
+class ImageSearchRequest(BaseModel):
+    """Search using a base64 encoded image."""
+    image_base64: str
+    top_k: int = 5
+    filters: Optional[Dict[str, List[str]]] = None

--- a/shared-types/ts/api.ts
+++ b/shared-types/ts/api.ts
@@ -20,3 +20,15 @@ export interface ChatRequest {
   session_id: string
   message: string
 }
+
+export interface TextSearchRequest {
+  query: string
+  top_k?: number
+  filters?: Record<string, string[]>
+}
+
+export interface ImageSearchRequest {
+  image_base64: string
+  top_k?: number
+  filters?: Record<string, string[]>
+}


### PR DESCRIPTION
## Summary
- implement FastAPI endpoints for text and image search
- use shared API models across backend and frontend
- provide simple React pages for search, image search and analytics
- update shared typings for new requests
- expand README with setup instructions and API overview

## Testing
- `python -m py_compile backend/app/main.py shared-types/api_models.py`
- `npx tsc --noEmit --project frontend/tsconfig.json` *(fails: cannot find modules)*