### PR TITLE
Fix backend module imports

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,14 +2,20 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from typing import List, Dict, Optional
+from typing import Dict
 
 from fastapi import FastAPI, HTTPException, UploadFile, File
 
 # allow importing modules from repository root
 ROOT_DIR = Path(__file__).resolve().parents[2]
 if str(ROOT_DIR) not in sys.path:
-    sys.path.append(str(ROOT_DIR))
+    sys.path.insert(0, str(ROOT_DIR))
+    # Redirect local "app" package to the repository root so imports like
+    # ``from app import qdrant_utils`` resolve correctly when running from this
+    # directory.
+    pkg = sys.modules.get("app")
+    if pkg and Path(getattr(pkg, "__file__", "")).parent == Path(__file__).parent:
+        pkg.__path__.insert(0, str(ROOT_DIR / "app"))
 
 from app import qdrant_utils, embedding, data_utils, openai_utils
 from shared_types.api_models import (
@@ -17,7 +23,6 @@ from shared_types.api_models import (
     HybridSearchRequest,
     ChatRequest,
     TextSearchRequest,
-    SearchResult,
 )
 
 import redis


### PR DESCRIPTION
## Summary
- change path insertion to `sys.path.insert(0, str(ROOT_DIR))`
- ensure backend package can resolve modules in the repo root
- drop unused imports

## Testing
- `uvicorn app.main:app --reload` *(fails to start due to missing `OPENAI_API_KEY` but modules load correctly)*